### PR TITLE
Up 365

### DIFF
--- a/src/renderer/components/Workspaces/WorkspaceList.css
+++ b/src/renderer/components/Workspaces/WorkspaceList.css
@@ -65,12 +65,6 @@
   background-color: var(--accent-color);
   opacity: 0.8;
 }
-
-.active-workspace {
-  background-color: var(--accent-color);
-  color: var(--whiteAndBlack);
-}
-
 .workspace-icon {
   font-size: 16px;
   margin-right: 10px;
@@ -90,48 +84,14 @@
 
 .tab-count {
   font-size: 11px;
-  color: var(--body-font-color);
-  background-color: var(--body-font-grey-shade);
+  color: var(--button-text);
+  background-color: var(--button-bg);
   opacity: 0.7;
   padding: 2px 6px;
   border-radius: 10px;
   margin-left: 8px;
   min-width: 32px;
   text-align: center;
-}
-
-/* Button Styles */
-.workspace-buttons {
-  padding: 8px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.new-workspace-button,
-.new-tab-button {
-  display: flex;
-  align-items: center;
-  padding: 8px;
-  margin: 2px 0;
-  width: 100%;
-  background-color: var(--whiteAndBlack);
-  color: var(--body-font-color);
-  border-radius: 4px;
-  cursor: pointer;
-  transition: all 0.2s;
-  font-size: 13px;
-}
-
-.workspace-buttons .new-tab-button {
-  width: calc(100% - 14px);
-  padding: 8px;
-}
-
-.new-workspace-button:hover,
-.new-tab-button:hover {
-  background-color: var(--accent-color);
-  color: var(--whiteAndBlack);
 }
 
 .new-workspace-button svg,
@@ -150,7 +110,6 @@
 
 #app-sidebar.narrow-sidebar .workspace-list {
   align-items: center;
-  /* Center all children horizontally */
 }
 
 #app-sidebar.narrow-sidebar .workspaces,
@@ -194,7 +153,7 @@
 }
 
 #app-sidebar.narrow-sidebar .active-workspace {
-  background-color: var(--accent-color);
+  background-color: var(--accent-color) !important;
   color: var(--whiteAndBlack);
   box-shadow: 0 0 0 2px var(--whiteAndBlack);
 }

--- a/src/renderer/css/styles.css
+++ b/src/renderer/css/styles.css
@@ -12,11 +12,7 @@
 #app-sidebar,
 .sidebar,
 .workspaces-sidebar {
-  background: linear-gradient(
-    135deg,
-    rgba(245, 245, 255, 0.87),
-    rgba(220, 225, 255, 0.72)
-  );
+  background: var(--sidebar-bg);
   backdrop-filter: blur(22px);
   border-radius: 22px;
   box-shadow: 0 6px 32px rgba(60, 60, 120, 0.08);
@@ -101,43 +97,32 @@
   margin-left: 80px !important;
 }
 
-.sidebar-section,
-.workspaces-section {
-  margin-bottom: 20px;
-  padding-bottom: 10px;
-  border-bottom: 1.5px solid rgba(120, 130, 180, 0.08);
-}
-
 /* Sidebar Action Buttons */
-.sidebar-btn,
 .new-tab-button,
 .new-workspace-button {
   display: flex;
   align-items: center;
-  background: linear-gradient(90deg, #e0e7ff 60%, #f1f5ff 100%);
+  background: var(--button-bg);
+  width: 100%;
   border: none;
   border-radius: 14px;
   padding: 13px 20px;
   font-size: 1.08rem;
   font-weight: 500;
-  color: #2d3150;
+  color: var(--button-text);
   margin-bottom: 10px;
   box-shadow: 0 2px 8px rgba(120, 130, 180, 0.06);
   transition: background 0.2s, box-shadow 0.2s, transform 0.18s;
   cursor: pointer;
   outline: none;
 }
-.sidebar-btn svg,
-.new-tab-button svg,
-.new-workspace-button svg {
-  margin-right: 11px;
-  font-size: 1.2em;
-}
+
 .sidebar-btn:hover,
 .sidebar-btn:focus,
 .new-tab-button:hover,
 .new-workspace-button:hover {
-  background: linear-gradient(90deg, #b5c6ff 60%, #e0e7ff 100%);
+  background: var(--button-hover-bg);
+  color: var(--button-text);
   box-shadow: 0 4px 16px rgba(120, 130, 180, 0.14);
   transform: scale(1.035);
 }
@@ -150,8 +135,7 @@
   flex-direction: column;
   gap: 6px;
 }
-.workspace-item,
-.sidebar-workspace-item {
+.workspace-item {
   display: flex;
   align-items: center;
   padding: 11px 16px;
@@ -160,31 +144,22 @@
   transition: background 0.2s, box-shadow 0.2s;
   cursor: pointer;
   font-size: 1rem;
-  color: #3a4060;
-  background: transparent;
+  color: var(--button-text);
+  background: var(--button-bg);
   border: none;
 }
-.workspace-item:hover,
-.sidebar-workspace-item:hover,
-.workspace-item.active,
-.sidebar-workspace-item.active {
-  background: rgba(120, 130, 255, 0.13);
+.workspace-item:hover{
+  background: var(--button-hover-bg);
   box-shadow: 0 2px 8px rgba(120, 130, 180, 0.08);
 }
-.workspace-item.active,
-.sidebar-workspace-item.active {
-  background: linear-gradient(90deg, #c7d2fe 60%, #e0e7ff 100%);
-  color: #2d3150;
-  font-weight: 600;
-  box-shadow: 0 4px 18px rgba(120, 130, 180, 0.16);
-  border-left: 4px solid #6366f1;
+.workspace-item.active-workspace {
+  background: var(--accent-color);
 }
 
-.sidebar-title,
 .workspaces-title {
   font-size: 1.12rem;
   font-weight: 600;
-  color: #2d3150;
+  color: var(--body-font-color);
   margin-bottom: 12px;
   letter-spacing: 0.01em;
 }
@@ -250,23 +225,27 @@ webview {
 }
 .top-bar #window-controls-close {
   background-color: #ff5a52;
+  color: var(--body-font-color);
 }
 .top-bar #window-controls-close svg,
 .top-bar #window-controls-unmaximize svg,
 .top-bar #window-controls-maximize svg,
 .top-bar #window-controls-minimize svg {
   background-color: transparent;
+  color: var(--body-font-color);
 }
 .top-bar #window-controls-unmaximize,
 .top-bar #window-controls-maximize {
   background-color: #51c23a;
+  color: var(--body-font-color);
 }
 
 .top-bar #window-controls-minimize {
   background-color: #e7c039;
+  color: var(--body-font-color);
 }
 .top-bar button:hover {
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--body-font-color);
 }
 #app-sidebar {
   position: fixed;
@@ -376,7 +355,7 @@ webview {
 #closeMenu {
   height: 30px;
   width: 30px;
-  color: white;
+  color: var(--body-font-color);
   font-size: 20px;
   border-radius: 50px;
   margin: 0.5rem;
@@ -384,7 +363,7 @@ webview {
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  background-color: #f47373;
+  background-color: var(--accent-color);
 }
 
 #menu-list {
@@ -409,16 +388,12 @@ webview {
 .menu-item-link:hover,
 .menu-item-link:active {
   background-color: var(--accent-color-hover);
-  color: #fff;
+  color: var(--body-font-color);
 }
 
 .menu-icon {
   font-size: 18px;
 }
-
-/* #menu-list .menu-item:hover {
-  border-radius: 20px 20px 20px 0 !important;
-}  */
 
 #menu.open {
   transform: scale(1, 1);
@@ -501,12 +476,14 @@ input {
   transition: all 0.2s ease;
   border: 1px solid transparent;
   background-color: var(--active-tab-bg);
+  color: var(--body-font-color);
   margin-left: 16px;
   margin-right: 16px;
   margin-bottom: 4px;
 }
 .tab:hover {
   background-color: var(--redish-shade-background);
+  color: var(--body-font-color);
 }
 .tab img {
   width: 18px;
@@ -537,8 +514,8 @@ input {
 }
 .tab .close:hover {
   opacity: 1;
-  background-color: var(--body-font-grey-shade);
-  opacity: 0.1;
+  color: var(--accent-color);
+  opacity: 0.8;
   border-radius: 50%;
 }
 .active-tab {
@@ -663,12 +640,12 @@ input {
   border-radius: 7px;
 }
 #savePasswordDialog button#save {
-  background-color: #e87874;
-  color: #fff;
+  background-color: var(--accent-color);
+  color: var(--body-font-color);
 }
 #savePasswordDialog button#never {
-  color: #e87874;
-  background-color: #fff;
+  color: var(--accent-color);
+  background-color: var(--body-backGround);
   box-shadow: 0 0 1px 1px var(--body-font-color);
 }
 @keyframes slide-up {
@@ -732,10 +709,6 @@ input {
   -webkit-app-region: no-drag;
 }
 
-.sidebar-item:hover {
-  background-color: var(--hover-bg);
-}
-
 .sidebar-item-icon {
   margin-right: 12px;
   font-size: 20px;
@@ -749,9 +722,6 @@ input {
 }
 
 /* Narrow mode styles */
-#app-sidebar.narrow-sidebar {
-  width: 80px !important;
-}
 
 #app-sidebar.narrow-sidebar .sidebar-content {
   display: flex;
@@ -775,40 +745,4 @@ input {
 /* Ensure smooth transitions */
 * {
   transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-/* Prevent conflicts between toggle and narrow modes */
-#app-sidebar.toggled-sidebar.narrow-sidebar {
-  width: 80px !important;
-}
-
-#app-sidebar.toggled-sidebar.narrow-sidebar .sidebar-content {
-  display: none;
-}
-
-/* Sidebar item styles */
-.sidebar-item {
-  display: flex;
-  align-items: center;
-  padding: 12px 16px;
-  color: var(--text-color);
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-  -webkit-app-region: no-drag;
-}
-
-.sidebar-item:hover {
-  background-color: var(--hover-bg);
-}
-
-.sidebar-item-icon {
-  margin-right: 12px;
-  font-size: 20px;
-}
-
-.sidebar-item-text {
-  font-size: 14px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }

--- a/src/renderer/css/theme.css
+++ b/src/renderer/css/theme.css
@@ -1,47 +1,75 @@
 :root {
+  /* Backgrounds */
   --root-background: #c1c2fa;
   --root-background-grad-1: #dddce0;
   --root-background-grad-2: #f0f0b2;
   --body-backGround: white;
   --body-backGround-transparent: transparent;
+
+  /* Text & Fonts */
   --body-font-color: black;
   --body-font-grey-shade: #333333ab;
+  --accent-color-reversed: black;
+
+  /* Buttons */
   --top-bar-button-bg: #0000001a;
+  --button-bg: linear-gradient(90deg, #e0e7ff 60%, #f1f5ff 100%);
+  --button-text: #2d3150;
+  --button-hover-bg: linear-gradient(90deg, #b5c6ff 60%, #e0e7ff 100%);
+
+  /* Tabs and Highlights */
   --redish-shade-background: #f2f2f2;
+  --active-tab-bg: #ffffff4b;
   --accent-color: #e87874;
   --accent-color-hover: #e87874;
-  --accent-color-reversed: black;
+
+  /* UI Decorations */
   --white-shadow-border: none;
-  --active-tab-bg: #ffffff4b;
   --empty-list-font: #1b274b;
   --window-controllers-icon-font: #333333b2;
   --search-location-container: #333333b2;
   --search-location-container-bg: #33333321;
   --whiteAndBlack: white;
   --workspace-list-bg: #beb8dd;
+  --sidebar-bg: linear-gradient(135deg, rgba(245, 245, 255, 0.87), rgba(220, 225, 255, 0.72));
   --invert: 0.5;
 }
 
 [data-theme="dark"] {
+  /* Backgrounds */
   --root-background: black;
   --root-background-grad-1: #7e7d7e;
   --root-background-grad-2: #252525;
-  --top-bar-button-bg: white;
-  --accent-color-hover: #562b29;
-  --accent-color-reversed: #e87874;
   --body-backGround: #000000d4;
+  --body-backGround-transparent: transparent;
+
+  /* Text & Fonts */
   --body-font-color: #ffffffda;
-  --body-backGround-transparent: #000000d4;
-  --redish-shade-background: #000000d4;
-  --border-thin: 1px solid #302c2c76;
   --body-font-grey-shade: #cccccc;
+  --accent-color-reversed: #e87874;
+
+  /* Buttons */
+  --top-bar-button-bg: white;
+  --sidebar-btn-bg: linear-gradient(90deg, #333333, #1a1a1a);
+  --button-bg: #ffffff10;
+  --button-text: #ffffffd9;
+  --button-hover-bg: linear-gradient(90deg, #3a3a3a 60%, #222222 100%);
+
+  /* Tabs and Highlights */
+  --redish-shade-background: #000000d4;
+  --active-tab-bg: #1a1a1a;
+  --accent-color-hover: #562b29;
+
+  /* UI Decorations */
+  --border-thin: 1px solid #302c2c76;
   --empty-list-font: #ffffffda;
   --window-controllers-icon-font: #333333b2;
-  --search-location-container: #a49a9ad7;
-  --search-location-container-bg: #33333321;
+  --search-location-container: #a49a9af9;
+  --search-location-container-bg: #333333;
   --whiteAndBlack: black;
+  --workspace-list-bg: #2c2c2c;
+  --sidebar-bg: linear-gradient(135deg, #1a1a1a, #111111);
   --invert: 1;
-  --workspace-list-bg: #beb8dd;
 }
 
 .popMenu {


### PR DESCRIPTION
# [UP-365 Fix Sidebar Panel Visibility and Functionality in Dark Mode](https://unellma.atlassian.net/browse/UP-365)

## Overview

This pull request addresses the issue where the sidebar panel was not visible or interactive when opening a new tab in dark mode in Unelma Browser. The sidebar is now fully visible, resizable, and matches the expected behavior in both light and dark modes.

## Issue Addressed

**Issue:**

- When dark mode is enabled and a user opens a new tab, the sidebar panel was not visible and could not be expanded or moved.

**Steps to Reproduce:**

1. Open Unelma Browser.
2. Navigate to the settings menu via … > Settings.
3. Enable "Dark Mode" and save settings.
4. Open a new tab.
5. Observe that the sidebar panel is not visible or interactive.

**Expected Behavior:**

- Sidebar panel should be visible and allow users to expand or move it left or right, increasing the main content area, in both light and dark modes.

## Summary of Changes

- **Sidebar and Workspace Styles Refactored:**
  - Updated sidebar, workspace, and button styles to use CSS variables for backgrounds and text, ensuring proper contrast and visibility in both light and dark modes.
  - Removed redundant and conflicting CSS rules for workspace items and buttons.
  - Ensured `.active-workspace` and related classes use theme variables for background and color.
  - Fixed narrow sidebar mode to use `!important` for active workspace background for consistency.
- **Component Refactor:**
  - Cleaned up `WorkspaceList.jsx` for more concise state management and handler functions.
  - Removed redundant comments and unused code.
  - Ensured workspace and tab creation, deletion, and renaming logic is clear and concise.
- **Theme Consistency:**
  - All sidebar and workspace elements now use theme variables for color and background, ensuring no visual glitches in dark mode.
  - Button and tab count styles now adapt to the current theme.

## Acceptance Criteria

- [x] Sidebar panel is visible when a new tab is opened in dark mode.
- [x] Sidebar can be expanded or moved left/right to adjust the main content area.
- [x] Sidebar panel's functionality matches its behavior in light mode (draggable, resizable).
- [x] The fix maintains compatibility with dark mode's color scheme and does not introduce visual glitches.
- [x] Test cases verify the sidebar behavior across multiple new tab instances.
## Screenshots
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/97759836-b587-4a90-aacc-037a986bc937" />

## Test Plan

- Switch between light and dark mode, open new tabs, and verify sidebar visibility and interactivity.
- Test sidebar resizing and expansion in both modes.
- Confirm no visual glitches or regressions in sidebar or workspace appearance.

---

**Please review and let me know if further adjustments are needed.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Unified color theming across the app using CSS variables for backgrounds, buttons, and sidebar elements.
	- Simplified and cleaned up sidebar and workspace list styling, removing redundant and unused styles.
	- Improved theming structure by adding and reorganizing CSS variables for both light and dark modes.
	- Enhanced consistency in button and tab appearance.
- **Refactor**
	- Removed unused workspace form UI and related logic from the workspace list.
	- Cleaned up and simplified component code for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->