### PR TITLE
fix: set custom user agent to enable WhatsApp Web support

### DIFF
--- a/src/main/Services/View.js
+++ b/src/main/Services/View.js
@@ -56,17 +56,21 @@ export class View {
         }
       }
       let preloadScript = UNELMA_BROWSER_PRELOAD_WEBPACK_ENTRY;
-      if (typeof url === 'string' && url.includes('youtube.com')) {
-        const path = require('path');
-        preloadScript = path.join(__dirname, 'preload_youtube.js');
+      if (typeof url === "string" && url.includes("youtube.com")) {
+        const path = require("path");
+        preloadScript = path.join(__dirname, "preload_youtube.js");
       }
       // Electron >=27: use preloadScripts, fallback to preload for older versions
-        this.view = new BrowserView({
-          webPreferences: {
-            preloadScripts: [preloadScript], // New API
-            // preload: preloadScript, // Uncomment if you want to support older Electron
-          },
-        });
+      this.view = new BrowserView({
+        webPreferences: {
+          preloadScripts: [preloadScript], // New API
+          // preload: preloadScript, // Uncomment if you want to support older Electron
+        },
+      });
+      // Set custom user agent to mimic Chrome
+      const customUserAgent =
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+      this.view.webContents.setUserAgent(customUserAgent);
       this.view.setBackgroundColor("white");
       this.view.setBounds({
         x: this.x,


### PR DESCRIPTION
# [UP-119](https://unellma.atlassian.net/browse/UP-119) Fix WhatsApp Web Compatibility by Setting Custom User Agent

## Summary

This PR resolves an issue where WhatsApp Web would not load in Unelma Browser, instead displaying a message requiring an update to Google Chrome. The problem was caused by WhatsApp Web blocking browsers with the default Electron user agent.

---

## Changes

- Set a custom user agent string in `src/main/Services/View.js` for all `BrowserView` instances.
- The new user agent mimics a recent version of Google Chrome, which is supported by WhatsApp Web and other modern web applications.

**Code added:**

```js
const customUserAgent =
  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
this.view.webContents.setUserAgent(customUserAgent);
```

---

## How to Test

1. Start the app: `npm start`
2. Open WhatsApp Web in a new tab.
3. You should now be able to log in and use WhatsApp Web without seeing the "update Chrome" message.

---

## Motivation

- Ensures compatibility with WhatsApp Web and other sites that block Electron's default user agent.
- Improves user experience for Unelma Browser users.

---

## Screenshots

|                     |                           |
| ---------------------------------------------- | -------------------------------------------- |
|  <img width="1438" alt="up-119-a" src="https://github.com/user-attachments/assets/5cd47af1-7db2-4137-8d80-679844ec80cd" /> |<img width="1438" alt="up-119" src="https://github.com/user-attachments/assets/e7abb3bc-85ef-4ffc-a24c-ffd4bc48e671" />  |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The browser view now uses a custom user agent string that mimics Chrome on macOS, which may improve compatibility with certain websites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->